### PR TITLE
remove eslint-disable-line from shown code

### DIFF
--- a/build/build.js
+++ b/build/build.js
@@ -90,6 +90,7 @@ getDirs(source).forEach(function (demoName) {
       lastBundleInDemo = impl.bundleName
       getFiles(implpath + '/src').forEach(function (file) {
         var content = fsx.readFileSync(implpath + '/src/' + file) + ''
+        content = content.replace('// eslint-disable-line', '')
         var filebasename = file.replace(/\.[^.]*$/, '')
         var suffix = file.match(/\.([^.]*)$/, '')[1]
         demo.filenames = uniq(demo.filenames.concat(filebasename))

--- a/pages/interval.html
+++ b/pages/interval.html
@@ -75,7 +75,7 @@
                 <tr>
                     <td>Vue (1.0.26)</td>
                     <td><a href="interval_vue_vanilla_info.html">vanilla</a></td>
-                    <td>540</td>
+                    <td>496</td>
                     <td>272609</td>
                     <td><a href="http://github.com/krawaller" target="_blank">krawaller</a></td>
                 </tr>

--- a/pages/interval_angular2_typescript_bootstrap.html
+++ b/pages/interval_angular2_typescript_bootstrap.html
@@ -105,7 +105,7 @@ ReactDOM.render(<span class="xml"><span class="hljs-tag">&lt;<span class="hljs-n
 
 <span class="hljs-keyword">import</span> <span class="hljs-string">'./singer'</span>
 
-<span class="hljs-keyword">new</span> Vue({ <span class="hljs-comment">// eslint-disable-line</span>
+<span class="hljs-keyword">new</span> Vue({ 
   template: <span class="hljs-string">'&lt;singer/&gt;'</span>,
   replace: <span class="hljs-literal">false</span>,
   el: <span class="hljs-string">'#app'</span>

--- a/pages/interval_angular2_typescript_singer.html
+++ b/pages/interval_angular2_typescript_singer.html
@@ -140,7 +140,7 @@
 <span class="hljs-keyword">let</span> lyrics = [<span class="hljs-string">'Eeexiiit light'</span>, <span class="hljs-string">'Eeenteeer niight'</span>, <span class="hljs-string">'Taaake my haaand'</span>, <span class="hljs-string">"We're off to never never land"</span>]
 
 Vue.component(<span class="hljs-string">'singer'</span>, {
-  template: <span class="hljs-string">`&lt;p&gt;{{line}}&lt;/p&gt;`</span>, <span class="hljs-comment">// eslint-disable-line</span>
+  template: <span class="hljs-string">`&lt;p&gt;{{line}}&lt;/p&gt;`</span>, 
   data: () =&gt; ({pos: <span class="hljs-number">0</span>}),
   computed: {
     line () {

--- a/pages/interval_cycle_lyricsdriver_bootstrap.html
+++ b/pages/interval_cycle_lyricsdriver_bootstrap.html
@@ -108,7 +108,7 @@ ReactDOM.render(<span class="xml"><span class="hljs-tag">&lt;<span class="hljs-n
 
 <span class="hljs-keyword">import</span> <span class="hljs-string">'./singer'</span>
 
-<span class="hljs-keyword">new</span> Vue({ <span class="hljs-comment">// eslint-disable-line</span>
+<span class="hljs-keyword">new</span> Vue({ 
   template: <span class="hljs-string">'&lt;singer/&gt;'</span>,
   replace: <span class="hljs-literal">false</span>,
   el: <span class="hljs-string">'#app'</span>

--- a/pages/interval_cycle_lyricsdriver_singer.html
+++ b/pages/interval_cycle_lyricsdriver_singer.html
@@ -143,7 +143,7 @@
 <span class="hljs-keyword">let</span> lyrics = [<span class="hljs-string">'Eeexiiit light'</span>, <span class="hljs-string">'Eeenteeer niight'</span>, <span class="hljs-string">'Taaake my haaand'</span>, <span class="hljs-string">"We're off to never never land"</span>]
 
 Vue.component(<span class="hljs-string">'singer'</span>, {
-  template: <span class="hljs-string">`&lt;p&gt;{{line}}&lt;/p&gt;`</span>, <span class="hljs-comment">// eslint-disable-line</span>
+  template: <span class="hljs-string">`&lt;p&gt;{{line}}&lt;/p&gt;`</span>, 
   data: () =&gt; ({pos: <span class="hljs-number">0</span>}),
   computed: {
     line () {

--- a/pages/interval_cycle_vanilla_bootstrap.html
+++ b/pages/interval_cycle_vanilla_bootstrap.html
@@ -105,7 +105,7 @@ ReactDOM.render(<span class="xml"><span class="hljs-tag">&lt;<span class="hljs-n
 
 <span class="hljs-keyword">import</span> <span class="hljs-string">'./singer'</span>
 
-<span class="hljs-keyword">new</span> Vue({ <span class="hljs-comment">// eslint-disable-line</span>
+<span class="hljs-keyword">new</span> Vue({ 
   template: <span class="hljs-string">'&lt;singer/&gt;'</span>,
   replace: <span class="hljs-literal">false</span>,
   el: <span class="hljs-string">'#app'</span>

--- a/pages/interval_cycle_vanilla_singer.html
+++ b/pages/interval_cycle_vanilla_singer.html
@@ -140,7 +140,7 @@
 <span class="hljs-keyword">let</span> lyrics = [<span class="hljs-string">'Eeexiiit light'</span>, <span class="hljs-string">'Eeenteeer niight'</span>, <span class="hljs-string">'Taaake my haaand'</span>, <span class="hljs-string">"We're off to never never land"</span>]
 
 Vue.component(<span class="hljs-string">'singer'</span>, {
-  template: <span class="hljs-string">`&lt;p&gt;{{line}}&lt;/p&gt;`</span>, <span class="hljs-comment">// eslint-disable-line</span>
+  template: <span class="hljs-string">`&lt;p&gt;{{line}}&lt;/p&gt;`</span>, 
   data: () =&gt; ({pos: <span class="hljs-number">0</span>}),
   computed: {
     line () {

--- a/pages/interval_preact_vanilla_bootstrap.html
+++ b/pages/interval_preact_vanilla_bootstrap.html
@@ -105,7 +105,7 @@ ReactDOM.render(<span class="xml"><span class="hljs-tag">&lt;<span class="hljs-n
 
 <span class="hljs-keyword">import</span> <span class="hljs-string">'./singer'</span>
 
-<span class="hljs-keyword">new</span> Vue({ <span class="hljs-comment">// eslint-disable-line</span>
+<span class="hljs-keyword">new</span> Vue({ 
   template: <span class="hljs-string">'&lt;singer/&gt;'</span>,
   replace: <span class="hljs-literal">false</span>,
   el: <span class="hljs-string">'#app'</span>

--- a/pages/interval_preact_vanilla_singer.html
+++ b/pages/interval_preact_vanilla_singer.html
@@ -140,7 +140,7 @@
 <span class="hljs-keyword">let</span> lyrics = [<span class="hljs-string">'Eeexiiit light'</span>, <span class="hljs-string">'Eeenteeer niight'</span>, <span class="hljs-string">'Taaake my haaand'</span>, <span class="hljs-string">"We're off to never never land"</span>]
 
 Vue.component(<span class="hljs-string">'singer'</span>, {
-  template: <span class="hljs-string">`&lt;p&gt;{{line}}&lt;/p&gt;`</span>, <span class="hljs-comment">// eslint-disable-line</span>
+  template: <span class="hljs-string">`&lt;p&gt;{{line}}&lt;/p&gt;`</span>, 
   data: () =&gt; ({pos: <span class="hljs-number">0</span>}),
   computed: {
     line () {

--- a/pages/interval_react_createclass_bootstrap.html
+++ b/pages/interval_react_createclass_bootstrap.html
@@ -105,7 +105,7 @@ render(<span class="xml"><span class="hljs-tag">&lt;<span class="hljs-name">Sing
 
 <span class="hljs-keyword">import</span> <span class="hljs-string">'./singer'</span>
 
-<span class="hljs-keyword">new</span> Vue({ <span class="hljs-comment">// eslint-disable-line</span>
+<span class="hljs-keyword">new</span> Vue({ 
   template: <span class="hljs-string">'&lt;singer/&gt;'</span>,
   replace: <span class="hljs-literal">false</span>,
   el: <span class="hljs-string">'#app'</span>

--- a/pages/interval_react_createclass_singer.html
+++ b/pages/interval_react_createclass_singer.html
@@ -140,7 +140,7 @@
 <span class="hljs-keyword">let</span> lyrics = [<span class="hljs-string">'Eeexiiit light'</span>, <span class="hljs-string">'Eeenteeer niight'</span>, <span class="hljs-string">'Taaake my haaand'</span>, <span class="hljs-string">"We're off to never never land"</span>]
 
 Vue.component(<span class="hljs-string">'singer'</span>, {
-  template: <span class="hljs-string">`&lt;p&gt;{{line}}&lt;/p&gt;`</span>, <span class="hljs-comment">// eslint-disable-line</span>
+  template: <span class="hljs-string">`&lt;p&gt;{{line}}&lt;/p&gt;`</span>, 
   data: () =&gt; ({pos: <span class="hljs-number">0</span>}),
   computed: {
     line () {

--- a/pages/interval_react_es6_bootstrap.html
+++ b/pages/interval_react_es6_bootstrap.html
@@ -105,7 +105,7 @@ render(<span class="xml"><span class="hljs-tag">&lt;<span class="hljs-name">Sing
 
 <span class="hljs-keyword">import</span> <span class="hljs-string">'./singer'</span>
 
-<span class="hljs-keyword">new</span> Vue({ <span class="hljs-comment">// eslint-disable-line</span>
+<span class="hljs-keyword">new</span> Vue({ 
   template: <span class="hljs-string">'&lt;singer/&gt;'</span>,
   replace: <span class="hljs-literal">false</span>,
   el: <span class="hljs-string">'#app'</span>

--- a/pages/interval_react_es6_singer.html
+++ b/pages/interval_react_es6_singer.html
@@ -140,7 +140,7 @@
 <span class="hljs-keyword">let</span> lyrics = [<span class="hljs-string">'Eeexiiit light'</span>, <span class="hljs-string">'Eeenteeer niight'</span>, <span class="hljs-string">'Taaake my haaand'</span>, <span class="hljs-string">"We're off to never never land"</span>]
 
 Vue.component(<span class="hljs-string">'singer'</span>, {
-  template: <span class="hljs-string">`&lt;p&gt;{{line}}&lt;/p&gt;`</span>, <span class="hljs-comment">// eslint-disable-line</span>
+  template: <span class="hljs-string">`&lt;p&gt;{{line}}&lt;/p&gt;`</span>, 
   data: () =&gt; ({pos: <span class="hljs-number">0</span>}),
   computed: {
     line () {

--- a/pages/interval_vue_vanilla_bootstrap.html
+++ b/pages/interval_vue_vanilla_bootstrap.html
@@ -37,7 +37,7 @@
 
 <span class="hljs-keyword">import</span> <span class="hljs-string">'./singer'</span>
 
-<span class="hljs-keyword">new</span> Vue({ <span class="hljs-comment">// eslint-disable-line</span>
+<span class="hljs-keyword">new</span> Vue({ 
   template: <span class="hljs-string">'&lt;singer/&gt;'</span>,
   replace: <span class="hljs-literal">false</span>,
   el: <span class="hljs-string">'#app'</span>

--- a/pages/interval_vue_vanilla_code.html
+++ b/pages/interval_vue_vanilla_code.html
@@ -37,7 +37,7 @@
 
 <span class="hljs-keyword">import</span> <span class="hljs-string">'./singer'</span>
 
-<span class="hljs-keyword">new</span> Vue({ <span class="hljs-comment">// eslint-disable-line</span>
+<span class="hljs-keyword">new</span> Vue({ 
   template: <span class="hljs-string">'&lt;singer/&gt;'</span>,
   replace: <span class="hljs-literal">false</span>,
   el: <span class="hljs-string">'#app'</span>
@@ -49,7 +49,7 @@
 <span class="hljs-keyword">let</span> lyrics = [<span class="hljs-string">'Eeexiiit light'</span>, <span class="hljs-string">'Eeenteeer niight'</span>, <span class="hljs-string">'Taaake my haaand'</span>, <span class="hljs-string">"We're off to never never land"</span>]
 
 Vue.component(<span class="hljs-string">'singer'</span>, {
-  template: <span class="hljs-string">`&lt;p&gt;{{line}}&lt;/p&gt;`</span>, <span class="hljs-comment">// eslint-disable-line</span>
+  template: <span class="hljs-string">`&lt;p&gt;{{line}}&lt;/p&gt;`</span>, 
   data: () =&gt; ({pos: <span class="hljs-number">0</span>}),
   computed: {
     line () {

--- a/pages/interval_vue_vanilla_info.html
+++ b/pages/interval_vue_vanilla_info.html
@@ -47,7 +47,7 @@
             <tbody>
                 <tr>
                     <td>Vue</td>
-                    <td>540</td>
+                    <td>496</td>
                     <td>272609</td>
                     <td><a href="http://github.com/krawaller" target="_blank">krawaller</a></td>
                     <td><a href="http://www.github.com/krawaller/jscomp/tree/gh-pages/demos/interval/vue/vanilla" target="_blank">link</a></td>

--- a/pages/interval_vue_vanilla_singer.html
+++ b/pages/interval_vue_vanilla_singer.html
@@ -38,7 +38,7 @@
 <span class="hljs-keyword">let</span> lyrics = [<span class="hljs-string">'Eeexiiit light'</span>, <span class="hljs-string">'Eeenteeer niight'</span>, <span class="hljs-string">'Taaake my haaand'</span>, <span class="hljs-string">"We're off to never never land"</span>]
 
 Vue.component(<span class="hljs-string">'singer'</span>, {
-  template: <span class="hljs-string">`&lt;p&gt;{{line}}&lt;/p&gt;`</span>, <span class="hljs-comment">// eslint-disable-line</span>
+  template: <span class="hljs-string">`&lt;p&gt;{{line}}&lt;/p&gt;`</span>, 
   data: () =&gt; ({pos: <span class="hljs-number">0</span>}),
   computed: {
     line () {

--- a/pages/localstorage.html
+++ b/pages/localstorage.html
@@ -61,7 +61,7 @@
                 <tr>
                     <td>Vue (1.0.26)</td>
                     <td><a href="localstorage_vue_vanilla_info.html">vanilla</a></td>
-                    <td>567</td>
+                    <td>545</td>
                     <td>272571</td>
                     <td><a href="http://github.com/krawaller" target="_blank">krawaller</a></td>
                 </tr>

--- a/pages/localstorage_angular2_typescript_bootstrap.html
+++ b/pages/localstorage_angular2_typescript_bootstrap.html
@@ -90,7 +90,7 @@ ReactDOM.render(<span class="xml"><span class="hljs-tag">&lt;<span class="hljs-n
 
 <span class="hljs-keyword">import</span> <span class="hljs-string">'./voter'</span>
 
-<span class="hljs-keyword">new</span> Vue({ <span class="hljs-comment">// eslint-disable-line</span>
+<span class="hljs-keyword">new</span> Vue({ 
   template: <span class="hljs-string">'&lt;voter/&gt;'</span>,
   replace: <span class="hljs-literal">false</span>,
   el: <span class="hljs-string">'#app'</span>

--- a/pages/localstorage_cycle_storagedriver_bootstrap.html
+++ b/pages/localstorage_cycle_storagedriver_bootstrap.html
@@ -93,7 +93,7 @@ ReactDOM.render(<span class="xml"><span class="hljs-tag">&lt;<span class="hljs-n
 
 <span class="hljs-keyword">import</span> <span class="hljs-string">'./voter'</span>
 
-<span class="hljs-keyword">new</span> Vue({ <span class="hljs-comment">// eslint-disable-line</span>
+<span class="hljs-keyword">new</span> Vue({ 
   template: <span class="hljs-string">'&lt;voter/&gt;'</span>,
   replace: <span class="hljs-literal">false</span>,
   el: <span class="hljs-string">'#app'</span>

--- a/pages/localstorage_react_createclass_bootstrap.html
+++ b/pages/localstorage_react_createclass_bootstrap.html
@@ -90,7 +90,7 @@ run(Voter, {
 
 <span class="hljs-keyword">import</span> <span class="hljs-string">'./voter'</span>
 
-<span class="hljs-keyword">new</span> Vue({ <span class="hljs-comment">// eslint-disable-line</span>
+<span class="hljs-keyword">new</span> Vue({ 
   template: <span class="hljs-string">'&lt;voter/&gt;'</span>,
   replace: <span class="hljs-literal">false</span>,
   el: <span class="hljs-string">'#app'</span>

--- a/pages/localstorage_react_es6class_bootstrap.html
+++ b/pages/localstorage_react_es6class_bootstrap.html
@@ -90,7 +90,7 @@ run(Voter, {
 
 <span class="hljs-keyword">import</span> <span class="hljs-string">'./voter'</span>
 
-<span class="hljs-keyword">new</span> Vue({ <span class="hljs-comment">// eslint-disable-line</span>
+<span class="hljs-keyword">new</span> Vue({ 
   template: <span class="hljs-string">'&lt;voter/&gt;'</span>,
   replace: <span class="hljs-literal">false</span>,
   el: <span class="hljs-string">'#app'</span>

--- a/pages/localstorage_vue_vanilla_bootstrap.html
+++ b/pages/localstorage_vue_vanilla_bootstrap.html
@@ -37,7 +37,7 @@
 
 <span class="hljs-keyword">import</span> <span class="hljs-string">'./voter'</span>
 
-<span class="hljs-keyword">new</span> Vue({ <span class="hljs-comment">// eslint-disable-line</span>
+<span class="hljs-keyword">new</span> Vue({ 
   template: <span class="hljs-string">'&lt;voter/&gt;'</span>,
   replace: <span class="hljs-literal">false</span>,
   el: <span class="hljs-string">'#app'</span>

--- a/pages/localstorage_vue_vanilla_code.html
+++ b/pages/localstorage_vue_vanilla_code.html
@@ -37,7 +37,7 @@
 
 <span class="hljs-keyword">import</span> <span class="hljs-string">'./voter'</span>
 
-<span class="hljs-keyword">new</span> Vue({ <span class="hljs-comment">// eslint-disable-line</span>
+<span class="hljs-keyword">new</span> Vue({ 
   template: <span class="hljs-string">'&lt;voter/&gt;'</span>,
   replace: <span class="hljs-literal">false</span>,
   el: <span class="hljs-string">'#app'</span>

--- a/pages/localstorage_vue_vanilla_info.html
+++ b/pages/localstorage_vue_vanilla_info.html
@@ -47,7 +47,7 @@
             <tbody>
                 <tr>
                     <td>Vue</td>
-                    <td>567</td>
+                    <td>545</td>
                     <td>272571</td>
                     <td><a href="http://github.com/krawaller" target="_blank">krawaller</a></td>
                     <td><a href="http://www.github.com/krawaller/jscomp/tree/gh-pages/demos/localstorage/vue/vanilla" target="_blank">link</a></td>

--- a/pages/simpleclicker.html
+++ b/pages/simpleclicker.html
@@ -117,7 +117,7 @@
                 <tr>
                     <td>Vue (1.0.26)</td>
                     <td><a href="simpleclicker_vue_vanilla_info.html">vanilla</a></td>
-                    <td>389</td>
+                    <td>367</td>
                     <td>272413</td>
                     <td><a href="http://github.com/krawaller" target="_blank">krawaller</a></td>
                 </tr>

--- a/pages/simpleclicker_angular2_javascript_bootstrap.html
+++ b/pages/simpleclicker_angular2_javascript_bootstrap.html
@@ -183,7 +183,7 @@ ReactDOM.render(<span class="xml"><span class="hljs-tag">&lt;<span class="hljs-n
 
 <span class="hljs-keyword">import</span> <span class="hljs-string">'./clicker'</span>
 
-<span class="hljs-keyword">new</span> Vue({ <span class="hljs-comment">// eslint-disable-line</span>
+<span class="hljs-keyword">new</span> Vue({ 
   template: <span class="hljs-string">'&lt;clicker/&gt;'</span>,
   replace: <span class="hljs-literal">false</span>,
   el: <span class="hljs-string">'#app'</span>

--- a/pages/simpleclicker_angular2_typescript_bootstrap.html
+++ b/pages/simpleclicker_angular2_typescript_bootstrap.html
@@ -183,7 +183,7 @@ ReactDOM.render(<span class="xml"><span class="hljs-tag">&lt;<span class="hljs-n
 
 <span class="hljs-keyword">import</span> <span class="hljs-string">'./clicker'</span>
 
-<span class="hljs-keyword">new</span> Vue({ <span class="hljs-comment">// eslint-disable-line</span>
+<span class="hljs-keyword">new</span> Vue({ 
   template: <span class="hljs-string">'&lt;clicker/&gt;'</span>,
   replace: <span class="hljs-literal">false</span>,
   el: <span class="hljs-string">'#app'</span>

--- a/pages/simpleclicker_angular_componentinline_bootstrap.html
+++ b/pages/simpleclicker_angular_componentinline_bootstrap.html
@@ -183,7 +183,7 @@ ReactDOM.render(<span class="xml"><span class="hljs-tag">&lt;<span class="hljs-n
 
 <span class="hljs-keyword">import</span> <span class="hljs-string">'./clicker'</span>
 
-<span class="hljs-keyword">new</span> Vue({ <span class="hljs-comment">// eslint-disable-line</span>
+<span class="hljs-keyword">new</span> Vue({ 
   template: <span class="hljs-string">'&lt;clicker/&gt;'</span>,
   replace: <span class="hljs-literal">false</span>,
   el: <span class="hljs-string">'#app'</span>

--- a/pages/simpleclicker_angular_componentseparate_bootstrap.html
+++ b/pages/simpleclicker_angular_componentseparate_bootstrap.html
@@ -183,7 +183,7 @@ ReactDOM.render(<span class="xml"><span class="hljs-tag">&lt;<span class="hljs-n
 
 <span class="hljs-keyword">import</span> <span class="hljs-string">'./clicker'</span>
 
-<span class="hljs-keyword">new</span> Vue({ <span class="hljs-comment">// eslint-disable-line</span>
+<span class="hljs-keyword">new</span> Vue({ 
   template: <span class="hljs-string">'&lt;clicker/&gt;'</span>,
   replace: <span class="hljs-literal">false</span>,
   el: <span class="hljs-string">'#app'</span>

--- a/pages/simpleclicker_angular_controller_bootstrap.html
+++ b/pages/simpleclicker_angular_controller_bootstrap.html
@@ -183,7 +183,7 @@ ReactDOM.render(<span class="xml"><span class="hljs-tag">&lt;<span class="hljs-n
 
 <span class="hljs-keyword">import</span> <span class="hljs-string">'./clicker'</span>
 
-<span class="hljs-keyword">new</span> Vue({ <span class="hljs-comment">// eslint-disable-line</span>
+<span class="hljs-keyword">new</span> Vue({ 
   template: <span class="hljs-string">'&lt;clicker/&gt;'</span>,
   replace: <span class="hljs-literal">false</span>,
   el: <span class="hljs-string">'#app'</span>

--- a/pages/simpleclicker_angular_controlleras_bootstrap.html
+++ b/pages/simpleclicker_angular_controlleras_bootstrap.html
@@ -183,7 +183,7 @@ ReactDOM.render(<span class="xml"><span class="hljs-tag">&lt;<span class="hljs-n
 
 <span class="hljs-keyword">import</span> <span class="hljs-string">'./clicker'</span>
 
-<span class="hljs-keyword">new</span> Vue({ <span class="hljs-comment">// eslint-disable-line</span>
+<span class="hljs-keyword">new</span> Vue({ 
   template: <span class="hljs-string">'&lt;clicker/&gt;'</span>,
   replace: <span class="hljs-literal">false</span>,
   el: <span class="hljs-string">'#app'</span>

--- a/pages/simpleclicker_angular_directive_bootstrap.html
+++ b/pages/simpleclicker_angular_directive_bootstrap.html
@@ -183,7 +183,7 @@ ReactDOM.render(<span class="xml"><span class="hljs-tag">&lt;<span class="hljs-n
 
 <span class="hljs-keyword">import</span> <span class="hljs-string">'./clicker'</span>
 
-<span class="hljs-keyword">new</span> Vue({ <span class="hljs-comment">// eslint-disable-line</span>
+<span class="hljs-keyword">new</span> Vue({ 
   template: <span class="hljs-string">'&lt;clicker/&gt;'</span>,
   replace: <span class="hljs-literal">false</span>,
   el: <span class="hljs-string">'#app'</span>

--- a/pages/simpleclicker_cycle_rxjs_bootstrap.html
+++ b/pages/simpleclicker_cycle_rxjs_bootstrap.html
@@ -183,7 +183,7 @@ ReactDOM.render(<span class="xml"><span class="hljs-tag">&lt;<span class="hljs-n
 
 <span class="hljs-keyword">import</span> <span class="hljs-string">'./clicker'</span>
 
-<span class="hljs-keyword">new</span> Vue({ <span class="hljs-comment">// eslint-disable-line</span>
+<span class="hljs-keyword">new</span> Vue({ 
   template: <span class="hljs-string">'&lt;clicker/&gt;'</span>,
   replace: <span class="hljs-literal">false</span>,
   el: <span class="hljs-string">'#app'</span>

--- a/pages/simpleclicker_cycle_xstream_bootstrap.html
+++ b/pages/simpleclicker_cycle_xstream_bootstrap.html
@@ -183,7 +183,7 @@ ReactDOM.render(<span class="xml"><span class="hljs-tag">&lt;<span class="hljs-n
 
 <span class="hljs-keyword">import</span> <span class="hljs-string">'./clicker'</span>
 
-<span class="hljs-keyword">new</span> Vue({ <span class="hljs-comment">// eslint-disable-line</span>
+<span class="hljs-keyword">new</span> Vue({ 
   template: <span class="hljs-string">'&lt;clicker/&gt;'</span>,
   replace: <span class="hljs-literal">false</span>,
   el: <span class="hljs-string">'#app'</span>

--- a/pages/simpleclicker_react_createclass_bootstrap.html
+++ b/pages/simpleclicker_react_createclass_bootstrap.html
@@ -183,7 +183,7 @@ run(Clicker, {
 
 <span class="hljs-keyword">import</span> <span class="hljs-string">'./clicker'</span>
 
-<span class="hljs-keyword">new</span> Vue({ <span class="hljs-comment">// eslint-disable-line</span>
+<span class="hljs-keyword">new</span> Vue({ 
   template: <span class="hljs-string">'&lt;clicker/&gt;'</span>,
   replace: <span class="hljs-literal">false</span>,
   el: <span class="hljs-string">'#app'</span>

--- a/pages/simpleclicker_react_es6_bootstrap.html
+++ b/pages/simpleclicker_react_es6_bootstrap.html
@@ -183,7 +183,7 @@ run(Clicker, {
 
 <span class="hljs-keyword">import</span> <span class="hljs-string">'./clicker'</span>
 
-<span class="hljs-keyword">new</span> Vue({ <span class="hljs-comment">// eslint-disable-line</span>
+<span class="hljs-keyword">new</span> Vue({ 
   template: <span class="hljs-string">'&lt;clicker/&gt;'</span>,
   replace: <span class="hljs-literal">false</span>,
   el: <span class="hljs-string">'#app'</span>

--- a/pages/simpleclicker_react_recompose_bootstrap.html
+++ b/pages/simpleclicker_react_recompose_bootstrap.html
@@ -183,7 +183,7 @@ run(Clicker, {
 
 <span class="hljs-keyword">import</span> <span class="hljs-string">'./clicker'</span>
 
-<span class="hljs-keyword">new</span> Vue({ <span class="hljs-comment">// eslint-disable-line</span>
+<span class="hljs-keyword">new</span> Vue({ 
   template: <span class="hljs-string">'&lt;clicker/&gt;'</span>,
   replace: <span class="hljs-literal">false</span>,
   el: <span class="hljs-string">'#app'</span>

--- a/pages/simpleclicker_vue_vanilla_bootstrap.html
+++ b/pages/simpleclicker_vue_vanilla_bootstrap.html
@@ -37,7 +37,7 @@
 
 <span class="hljs-keyword">import</span> <span class="hljs-string">'./clicker'</span>
 
-<span class="hljs-keyword">new</span> Vue({ <span class="hljs-comment">// eslint-disable-line</span>
+<span class="hljs-keyword">new</span> Vue({ 
   template: <span class="hljs-string">'&lt;clicker/&gt;'</span>,
   replace: <span class="hljs-literal">false</span>,
   el: <span class="hljs-string">'#app'</span>

--- a/pages/simpleclicker_vue_vanilla_code.html
+++ b/pages/simpleclicker_vue_vanilla_code.html
@@ -37,7 +37,7 @@
 
 <span class="hljs-keyword">import</span> <span class="hljs-string">'./clicker'</span>
 
-<span class="hljs-keyword">new</span> Vue({ <span class="hljs-comment">// eslint-disable-line</span>
+<span class="hljs-keyword">new</span> Vue({ 
   template: <span class="hljs-string">'&lt;clicker/&gt;'</span>,
   replace: <span class="hljs-literal">false</span>,
   el: <span class="hljs-string">'#app'</span>

--- a/pages/simpleclicker_vue_vanilla_info.html
+++ b/pages/simpleclicker_vue_vanilla_info.html
@@ -47,7 +47,7 @@
             <tbody>
                 <tr>
                     <td>Vue</td>
-                    <td>389</td>
+                    <td>367</td>
                     <td>272413</td>
                     <td><a href="http://github.com/krawaller" target="_blank">krawaller</a></td>
                     <td><a href="http://www.github.com/krawaller/jscomp/tree/gh-pages/demos/simpleclicker/vue/vanilla" target="_blank">link</a></td>

--- a/pages/twoway.html
+++ b/pages/twoway.html
@@ -54,7 +54,7 @@
                 <tr>
                     <td>Vue (1.0.26)</td>
                     <td><a href="twoway_vue_vanilla_info.html">vanilla</a></td>
-                    <td>479</td>
+                    <td>457</td>
                     <td>272505</td>
                     <td><a href="http://github.com/krawaller" target="_blank">krawaller</a></td>
                 </tr>

--- a/pages/twoway_angular2_typescript_bootstrap.html
+++ b/pages/twoway_angular2_typescript_bootstrap.html
@@ -83,7 +83,7 @@ ReactDOM.render(<span class="xml"><span class="hljs-tag">&lt;<span class="hljs-n
 
 <span class="hljs-keyword">import</span> <span class="hljs-string">'./phonebooth'</span>
 
-<span class="hljs-keyword">new</span> Vue({ <span class="hljs-comment">// eslint-disable-line</span>
+<span class="hljs-keyword">new</span> Vue({ 
   template: <span class="hljs-string">'&lt;phonebooth/&gt;'</span>,
   replace: <span class="hljs-literal">false</span>,
   el: <span class="hljs-string">'#app'</span>

--- a/pages/twoway_cycle_xstream_bootstrap.html
+++ b/pages/twoway_cycle_xstream_bootstrap.html
@@ -86,7 +86,7 @@ ReactDOM.render(<span class="xml"><span class="hljs-tag">&lt;<span class="hljs-n
 
 <span class="hljs-keyword">import</span> <span class="hljs-string">'./phonebooth'</span>
 
-<span class="hljs-keyword">new</span> Vue({ <span class="hljs-comment">// eslint-disable-line</span>
+<span class="hljs-keyword">new</span> Vue({ 
   template: <span class="hljs-string">'&lt;phonebooth/&gt;'</span>,
   replace: <span class="hljs-literal">false</span>,
   el: <span class="hljs-string">'#app'</span>

--- a/pages/twoway_react_createclass_bootstrap.html
+++ b/pages/twoway_react_createclass_bootstrap.html
@@ -83,7 +83,7 @@ run(Phonebooth, {
 
 <span class="hljs-keyword">import</span> <span class="hljs-string">'./phonebooth'</span>
 
-<span class="hljs-keyword">new</span> Vue({ <span class="hljs-comment">// eslint-disable-line</span>
+<span class="hljs-keyword">new</span> Vue({ 
   template: <span class="hljs-string">'&lt;phonebooth/&gt;'</span>,
   replace: <span class="hljs-literal">false</span>,
   el: <span class="hljs-string">'#app'</span>

--- a/pages/twoway_vue_vanilla_bootstrap.html
+++ b/pages/twoway_vue_vanilla_bootstrap.html
@@ -37,7 +37,7 @@
 
 <span class="hljs-keyword">import</span> <span class="hljs-string">'./phonebooth'</span>
 
-<span class="hljs-keyword">new</span> Vue({ <span class="hljs-comment">// eslint-disable-line</span>
+<span class="hljs-keyword">new</span> Vue({ 
   template: <span class="hljs-string">'&lt;phonebooth/&gt;'</span>,
   replace: <span class="hljs-literal">false</span>,
   el: <span class="hljs-string">'#app'</span>

--- a/pages/twoway_vue_vanilla_code.html
+++ b/pages/twoway_vue_vanilla_code.html
@@ -37,7 +37,7 @@
 
 <span class="hljs-keyword">import</span> <span class="hljs-string">'./phonebooth'</span>
 
-<span class="hljs-keyword">new</span> Vue({ <span class="hljs-comment">// eslint-disable-line</span>
+<span class="hljs-keyword">new</span> Vue({ 
   template: <span class="hljs-string">'&lt;phonebooth/&gt;'</span>,
   replace: <span class="hljs-literal">false</span>,
   el: <span class="hljs-string">'#app'</span>

--- a/pages/twoway_vue_vanilla_info.html
+++ b/pages/twoway_vue_vanilla_info.html
@@ -47,7 +47,7 @@
             <tbody>
                 <tr>
                     <td>Vue</td>
-                    <td>479</td>
+                    <td>457</td>
                     <td>272505</td>
                     <td><a href="http://github.com/krawaller" target="_blank">krawaller</a></td>
                     <td><a href="http://www.github.com/krawaller/jscomp/tree/gh-pages/demos/twoway/vue/vanilla" target="_blank">link</a></td>


### PR DESCRIPTION
Earlier I added some `// eslint-disable-line` in the vue code files to make Standard happy, but these are not at all relevant to the implementation so with this PR I have added a simple replace in the build that removes these comments from the rendered html. 

It would of course be better to fix the vue files to adhere to the styling rules - I think it was [no-new](http://eslint.org/docs/rules/no-new) and something more - but I have no experience with vue so I just did the old hacky solution. 
