### PR TITLE
pathhelper function and readfile encoding

### DIFF
--- a/build/build.js
+++ b/build/build.js
@@ -172,8 +172,8 @@ data.demos.forEach(demo => {
         codeFiles: impl.files
       }).concat(impl.files)
       fsx.copySync(
-        pathHelper(`../demos/${demo.folderName}/${framework.folderName}/${impl.folderName}/bundle.js`),
-        pathHelper(`../pages/scripts/${demo.folderName}_${framework.folderName}_${impl.folderName}.js`)
+        `${source}${demo.folderName}/${framework.folderName}/${impl.folderName}/bundle.js`,
+        `${output}scripts/${demo.folderName}_${framework.folderName}_${impl.folderName}.js`
       )
       sections.forEach(file => {
         const path = `${output}${demo.folderName}_${impl.framework}_${impl.folderName}_${file.filename}.html`

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "scripts": {
     "prebuild": "npm run lint",
-    "build": "cd build && node build.js",
+    "build": "node build/build.js",
     "lint": "standard 'demos/**/*.js'",
     "lint:fix": "standard 'demos/**/*.js' --fix"
   },


### PR DESCRIPTION
The fiddling continues! 

Added a tiny pathHelper function so we can run the build without `cd`ing into the build-folder. Also added the `{encoding: 'utf-8'}` option to the readFileSync's so it spits out string directly. 
